### PR TITLE
Reduce product stamp size by 60%

### DIFF
--- a/template/scss/custom-css/_styles.scss
+++ b/template/scss/custom-css/_styles.scss
@@ -1620,12 +1620,12 @@
 }
 .product__stamps img,
 .product-card__stamps img {
-  max-width: 168px;
+  max-width: 67px;
 }
 
 @media (max-width: 768px) {
   .product__stamps img,
   .product-card__stamps img {
-    max-width: 137px;
+    max-width: 55px;
   }
 }


### PR DESCRIPTION
## Summary
- Previous increase (168px/137px) looked too large in production on the product page.
- Reduces `.product__stamps`/`.product-card__stamps` img max-width by 60%: 168px → 67px (desktop), 137px → 55px (mobile).

## Test plan
- [ ] Check https://www.blowgummies.com.br/blow-gummies-360-dias renders the stamp at a reasonable size on desktop and mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)