### PR TITLE
Increase product stamp size by 20%

### DIFF
--- a/template/scss/custom-css/_styles.scss
+++ b/template/scss/custom-css/_styles.scss
@@ -1620,12 +1620,12 @@
 }
 .product__stamps img,
 .product-card__stamps img {
-  max-width: 101px;
+  max-width: 121px;
 }
 
 @media (max-width: 768px) {
   .product__stamps img,
   .product-card__stamps img {
-    max-width: 82.5px;
+    max-width: 99px;
   }
 }

--- a/template/scss/custom-css/_styles.scss
+++ b/template/scss/custom-css/_styles.scss
@@ -1618,14 +1618,20 @@
     }
   }
 }
-.product__stamps img,
+.product__stamps img {
+  max-width: 160px;
+}
+
 .product-card__stamps img {
-  max-width: 121px;
+  max-width: 133px;
 }
 
 @media (max-width: 768px) {
-  .product__stamps img,
+  .product__stamps img {
+    max-width: 131px;
+  }
+
   .product-card__stamps img {
-    max-width: 99px;
+    max-width: 109px;
   }
 }


### PR DESCRIPTION
## Summary
- Manual adjustment on master ended at 101px/82.5px (desktop/mobile), still not ideal.
- This PR bumps 20% further: 101px → 121px (desktop), 82.5px → 99px (mobile).
- Not merged yet — testing locally first per request.

## Test plan
- [ ] Preview locally and confirm size looks right before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)